### PR TITLE
Cryptography

### DIFF
--- a/Algorithms/Algorithms.Core/Hashing/Cryptographer.cs
+++ b/Algorithms/Algorithms.Core/Hashing/Cryptographer.cs
@@ -4,30 +4,32 @@ using System.Security.Cryptography;
 
 namespace Algorithms.Core.Hashing
 {
-   public abstract class Cryptographer
-   {
-      static readonly MD5 md5 = MD5.Create();
-      static readonly SHA256 sha256 = SHA256.Create();
-      static readonly SHA512 sha512 = SHA512.Create();
+    public abstract class Cryptographer
+    {
+#pragma warning disable CA5351
+        static readonly MD5 md5 = MD5.Create();
+#pragma warning restore CA5351
+        static readonly SHA256 sha256 = SHA256.Create();
+        static readonly SHA512 sha512 = SHA512.Create();
 
-      public byte[] Hash(HashType hash, string plainText)
-      {
-         if (!string.IsNullOrEmpty(plainText))
-         {
-            switch (hash)
+        public byte[] Hash(HashType hash, string plainText)
+        {
+            if (!string.IsNullOrEmpty(plainText))
             {
-               case HashType.MD5:
-                  return md5.ComputeHash(Encoding.UTF8.GetBytes(plainText));
-               case HashType.SHA256:
-                  return sha256.ComputeHash(Encoding.UTF8.GetBytes(plainText));
-               case HashType.SHA512:
-                  return sha512.ComputeHash(Encoding.UTF8.GetBytes(plainText));
-               default:
-                  break;
+                switch (hash)
+                {
+                    case HashType.MD5:
+                        return md5.ComputeHash(Encoding.UTF8.GetBytes(plainText));
+                    case HashType.SHA256:
+                        return sha256.ComputeHash(Encoding.UTF8.GetBytes(plainText));
+                    case HashType.SHA512:
+                        return sha512.ComputeHash(Encoding.UTF8.GetBytes(plainText));
+                    default:
+                        break;
+                }
             }
-         }
 
-         return new byte[0];
-      }
-   }
+            return new byte[0];
+        }
+    }
 }


### PR DESCRIPTION
- Received compiler error when using MD5 hash algorithm
  - md5 uses a broken cryptographic algorithm MD5 (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca5351)
  - Suprresing the warning as MD5 is used for non-security purposes, mainly as a case study